### PR TITLE
Add constraint of height to search bar for iOS 11

### DIFF
--- a/Papr/Scenes/Search/SearchViewController.swift
+++ b/Papr/Scenes/Search/SearchViewController.swift
@@ -87,6 +87,10 @@ class SearchViewController: UIViewController, BindableType {
         searchBar.searchBarStyle = .default
         searchBar.placeholder = "Search Unsplash"
         navigationItem.titleView = searchBar
+
+        if #available(iOS 11.0, *) {
+            searchBar.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        }
     }
 
     private func configureTableView() {


### PR DESCRIPTION
iOS 11~ UISearchBar now has the height equals to 56. 
If you still want to have UISearchBar as titleView, simply set constraint height to 44 in iOS11~ 