### PR TITLE
Remove curated collections

### DIFF
--- a/Papr/Scenes/Collections/CollectionsViewModel.swift
+++ b/Papr/Scenes/Collections/CollectionsViewModel.swift
@@ -88,7 +88,7 @@ class CollectionsViewModel: CollectionsViewModelType,
             .flatMapLatest { isRefreshing -> Observable<[PhotoCollection]> in
                 guard isRefreshing else { return .empty() }
                 return service
-                    .collections(byPageNumber: 1, curated: false)
+                    .collections(byPageNumber: 1)
                     .flatMap { [unowned self] result -> Observable<[PhotoCollection]> in
                         switch result {
                         case let .success(photoCollections):
@@ -109,7 +109,7 @@ class CollectionsViewModel: CollectionsViewModelType,
                 guard isLoadingMore else { return .empty() }
                 currentPageNumber += 1
                 return service
-                    .collections(byPageNumber: currentPageNumber, curated: false)
+                    .collections(byPageNumber: currentPageNumber)
                     .flatMap { [unowned self] result -> Observable<[PhotoCollection]> in
                         switch result {
                         case let .success(photoCollections):

--- a/Papr/Services/CollectionService/CollectionService.swift
+++ b/Papr/Services/CollectionService/CollectionService.swift
@@ -33,10 +33,8 @@ struct CollectionService: CollectionServiceType {
                 .asObservable()
     }
 
-    func collections(byPageNumber page: Int, curated: Bool) -> Observable<Result<[PhotoCollection], String>> {
-        let collections: Unsplash = curated ?
-            .curatedCollections(page: page, perPage: 20) :
-            .featuredCollections(page: page, perPage: 20)
+    func collections(byPageNumber page: Int) -> Observable<Result<[PhotoCollection], String>> {
+        let collections: Unsplash = .featuredCollections(page: page, perPage: 20)
 
         return unsplash.rx.request(resource: collections)
             .map(to: [PhotoCollection].self)

--- a/Papr/Services/CollectionService/CollectionServiceType.swift
+++ b/Papr/Services/CollectionService/CollectionServiceType.swift
@@ -19,7 +19,7 @@ protocol CollectionServiceType {
     
     func collections(withUsername username: String) -> Observable<[PhotoCollection]>
 
-    func collections(byPageNumber page: Int, curated: Bool) -> Observable<Result<[PhotoCollection], String>>
+    func collections(byPageNumber page: Int) -> Observable<Result<[PhotoCollection], String>>
 
     func photos(fromCollectionId id: Int, pageNumber: Int) -> Observable<[Photo]>
     

--- a/Papr/Utils/Enums/Unsplash/Unsplash.swift
+++ b/Papr/Utils/Enums/Unsplash/Unsplash.swift
@@ -133,28 +133,14 @@ enum Unsplash {
         page: Int?,
         perPage: Int?)
 
-    /// Get a list of curated collections
-    case curatedCollections(
-        page: Int?,
-        perPage: Int?)
-
     /// Retrieve a collection
     case collection(id: Int)
-
-    /// Retrieve a curated collection
-    case curatedCollection(id: Int)
 
     /// Retrieve a related collection
     case relatedCollections(id: Int)
 
     /// Retrieve a collection’s photos
     case collectionPhotos(
-        id: Int,
-        page: Int?,
-        perPage: Int?)
-
-    /// Retrieve a curated collection’s photos
-    case curatedCollectionPhotos(
         id: Int,
         page: Int?,
         perPage: Int?)
@@ -243,16 +229,10 @@ extension Unsplash: Resource {
             return .post(path: "/collections")
         case .featuredCollections:
             return .get(path: "/collections/featured")
-        case .curatedCollections:
-            return .get(path: "/collections/curated")
         case let .collection(id):
             return .get(path: "/collections/\(id)")
-        case let .curatedCollection(id):
-            return .get(path: "/collections/curated\(id)")
         case let .collectionPhotos(params):
             return .get(path: "/collections/\(params.id)/photos")
-        case let .curatedCollectionPhotos(params):
-            return .get(path: "/collections/curated/\(params.id)/photos")
         case let .relatedCollections(id):
             return .get(path: "/collections/\(id)/related")
         case let .updateCollection(params):
@@ -352,9 +332,7 @@ extension Unsplash: Resource {
         case let .userCollections(_, pageNumber, photosPerPage),
              let .collections(pageNumber, photosPerPage),
              let .featuredCollections(pageNumber, photosPerPage),
-             let .curatedCollections(pageNumber, photosPerPage),
-             let .collectionPhotos(_, pageNumber, photosPerPage),
-             let .curatedCollectionPhotos(_, pageNumber, photosPerPage):
+             let .collectionPhotos(_, pageNumber, photosPerPage):
 
             var params: [String: Any] = [:]
             params["page"] = pageNumber


### PR DESCRIPTION
Curated collection are not removed from the Unsplash API. For this reason I am removing the endpoints and the code related it these.