### PR TITLE
Add error handling to avoid crash if getting error reponse from loading image

### DIFF
--- a/Papr/Custom UI/PaprNavigationController.swift
+++ b/Papr/Custom UI/PaprNavigationController.swift
@@ -85,6 +85,7 @@ class PaprNavigationController: UINavigationController {
             .unwrap()
             .mapToURL()
             .flatMap { PaprNavigationController.imagePipeline.rx.loadImage(with: $0) }
+            .orEmpty()
             .map { $0.image }
             .bind(to: profileImage.rx.image)
             .disposed(by: disposeBag)

--- a/Papr/Scenes/Add to collection/AddToCollectionViewController.swift
+++ b/Papr/Scenes/Add to collection/AddToCollectionViewController.swift
@@ -52,6 +52,7 @@ class AddToCollectionViewController: UIViewController, BindableType {
             .unwrap()
             .mapToURL()
             .flatMap { this.imagePipeline.rx.loadImage(with: $0) }
+            .orEmpty()
             .map { $0.image }
             .execute { [unowned self] _ in
                 self.photoActivityIndicator.stopAnimating()

--- a/Papr/Scenes/Add to collection/Cell/PhotoCollectionViewCell.swift
+++ b/Papr/Scenes/Add to collection/Cell/PhotoCollectionViewCell.swift
@@ -66,6 +66,7 @@ class PhotoCollectionViewCell: UICollectionViewCell, BindableType, NibIdentifiab
         outputs.coverPhotoURL
             .mapToURL()
             .flatMap { this.imagePipeline.rx.loadImage(with: $0) }
+            .orEmpty()
             .map { $0.image }
             .execute { [unowned self] _ in
                 self.activityIndicator.stopAnimating()

--- a/Papr/Scenes/Collections/Cell/CollectionCell.swift
+++ b/Papr/Scenes/Collections/Cell/CollectionCell.swift
@@ -79,6 +79,7 @@ class CollectionCell: UICollectionViewCell, BindableType, NibIdentifiable & Clas
                     this.imagePipeline.rx.loadImage(with: URL(string: regular)!).asObservable()
                 )
             }
+            .orEmpty()
             .map { $0.image }
             .bind(to: photoCollectionImagePreview.rx.image)
             .disposed(by: disposeBag)

--- a/Papr/Scenes/Home/Cell/Header/HomeViewCellHeader.swift
+++ b/Papr/Scenes/Home/Cell/Header/HomeViewCellHeader.swift
@@ -53,6 +53,7 @@ class HomeViewCellHeader: UIView, BindableType {
 
         outputs.profileImageURL
             .flatMap { this.imagePipeline.rx.loadImage(with: $0) }
+            .orEmpty()
             .map { $0.image }
             .bind(to: profileImageView.rx.image)
             .disposed(by: disposeBag)

--- a/Papr/Scenes/Home/Cell/HomeViewCell.swift
+++ b/Papr/Scenes/Home/Cell/HomeViewCell.swift
@@ -75,10 +75,7 @@ class HomeViewCell: UICollectionViewCell, BindableType,  ClassIdentifiable {
                     this.imagePipeline.rx.loadImage(with: URL(string: full)!).asObservable()
                 )
         }
-            .catchError {
-                debugPrint($0.localizedDescription)
-                return .empty()
-            }
+            .orEmpty()
             .map { $0.image }
             .bind(to: photoImageView.rx.image)
             .disposed(by: disposeBag)

--- a/Papr/Scenes/Home/Cell/HomeViewCell.swift
+++ b/Papr/Scenes/Home/Cell/HomeViewCell.swift
@@ -63,7 +63,7 @@ class HomeViewCell: UICollectionViewCell, BindableType,  ClassIdentifiable {
                 self?.photoButton.rx.bind(to: inputs.photoDetailsAction, input: $0)
             }
             .disposed(by: disposeBag)
-
+        
         Observable.combineLatest(
             outputs.smallPhoto,
             outputs.regularPhoto,
@@ -74,6 +74,10 @@ class HomeViewCell: UICollectionViewCell, BindableType,  ClassIdentifiable {
                     this.imagePipeline.rx.loadImage(with: URL(string: regular)!).asObservable(),
                     this.imagePipeline.rx.loadImage(with: URL(string: full)!).asObservable()
                 )
+        }
+            .catchError {
+                debugPrint($0.localizedDescription)
+                return .empty()
             }
             .map { $0.image }
             .bind(to: photoImageView.rx.image)

--- a/Papr/Scenes/Login/LoginViewController.swift
+++ b/Papr/Scenes/Login/LoginViewController.swift
@@ -68,7 +68,9 @@ class LoginViewController: UIViewController, BindableType {
         
         outputs.randomPhotos
             .map { $0.compactMap { $0.urls?.regular } }
-            .mapMany { this.imagePipeline.rx.loadImage(with: URL(string: $0)!).asObservable() }
+            .mapMany {
+                this.imagePipeline.rx.loadImage(with: URL(string: $0)!).asObservable().orEmpty()
+        }
             .mapMany { $0.map { $0.image } }
             .flatMap(Observable.combineLatest)
             .map { UIImage.animatedImage(with: $0, duration: 60.0) }

--- a/Papr/Scenes/Photo Details/PhotoDetailsViewController.swift
+++ b/Papr/Scenes/Photo Details/PhotoDetailsViewController.swift
@@ -75,6 +75,7 @@ class PhotoDetailsViewController: UIViewController, BindableType {
         outputs.regularPhoto
             .mapToURL()
             .flatMap { this.imagePipeline.rx.loadImage(with: $0) }
+            .orEmpty()
             .map { $0.image }
             .bind(to: photoImageView.rx.image)
             .disposed(by: disposeBag)

--- a/Papr/Scenes/Search/SearchPhotos/Cell/SearchPhotosCell.swift
+++ b/Papr/Scenes/Search/SearchPhotos/Cell/SearchPhotosCell.swift
@@ -55,6 +55,7 @@ class SearchPhotosCell: UICollectionViewCell, BindableType, NibIdentifiable & Cl
                     this.imagePipeline.rx.loadImage(with: URL(string: regular)!).asObservable()
                 )
             }
+            .orEmpty()
             .map { $0.image }
             .execute { [unowned self] _ in
                 self.activityIndicator.stopAnimating()

--- a/Papr/Scenes/Search/SearchUsers/Cell/UserCell.swift
+++ b/Papr/Scenes/Search/SearchUsers/Cell/UserCell.swift
@@ -49,6 +49,7 @@ class UserCell: UITableViewCell, BindableType, NibIdentifiable & ClassIdentifiab
         outputs.profilePhotoURL
             .mapToURL()
             .flatMap { this.imagePipeline.rx.loadImage(with: $0) }
+            .orEmpty()
             .map { $0.image }
             .bind(to: profilePhotoImageView.rx.image)
             .disposed(by: disposeBag)

--- a/Papr/Utils/Extentions/Rx/ObservableType+Extras.swift
+++ b/Papr/Utils/Extentions/Rx/ObservableType+Extras.swift
@@ -43,6 +43,12 @@ extension ObservableType {
         return Observable.merge(self.asObservable(), other)
     }
     
+    func orEmpty() -> Observable<Element> {
+        return catchError { _ in
+            return .empty()
+        }
+    }
+    
 }
 extension Observable where Element == String {
 


### PR DESCRIPTION
If any of the image requests get an error response, it will crash since binding error.  Catch error and return an empty observable or a placeholder image to avoid the crash.